### PR TITLE
Fix example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ password = None
 apiKey = None
 console_topic = "_owntracks/_look/#"
 maptopic = "_owntracks/_map/+/+/+"
+jobtopic = "_owntracks/_job/+/+/+"
 topic_visible = False
 ```
 


### PR DESCRIPTION
The current example configuration shown in the README is broken. Running `pista.py` throws the following exception:

    Traceback (most recent call last):
      File "/home/z38/dev/gps/pista/venv/local/lib/python2.7/site-packages/bottle.py", line 862, in _handle
        return route.call(**args)
      File "/home/z38/dev/gps/pista/venv/local/lib/python2.7/site-packages/bottle.py", line 1732, in wrapper
        rv = callback(*a, **ka)
      File "/home/z38/dev/gps/pista/venv/local/lib/python2.7/site-packages/bottle.py", line 2680, in wrapper
        return func(*a, **ka)
      File "./pista.py", line 444, in config_js
        return template('config-js', newconf)
      File "/home/z38/dev/gps/pista/venv/local/lib/python2.7/site-packages/bottle.py", line 3595, in template
        return TEMPLATES[tplid].render(kwargs)
      File "/home/z38/dev/gps/pista/venv/local/lib/python2.7/site-packages/bottle.py", line 3399, in render
        self.execute(stdout, env)
      File "/home/z38/dev/gps/pista/venv/local/lib/python2.7/site-packages/bottle.py", line 3386, in execute
        eval(self.co, env)
      File "/home/z38/dev/gps/pista/views/config-js.tpl", line 32, in <module>
        jobtopic: {{ !jobtopic }},
    NameError: name 'jobtopic' is not defined

This little patch should fix this issue.